### PR TITLE
fix: better return types to override undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,8 @@ type DeepMerge<T, U> =
 		U extends Record<string, unknown> ?
 			{[K in keyof T | keyof U]: K extends keyof T ? K extends keyof U ? DeepMerge<T[K], U[K]> : T[K] : K extends keyof U ? U[K] : never}
 			: T
-		: U;
+		: U extends undefined ?
+			T extends undefined ?
+				U
+				: T
+			: U;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -45,3 +45,22 @@ import defaults from './index.js';
 	console.log(a.b); // Expect output to be 1
 	console.log(a.c); // Expect output to be 2
 }
+
+// Test that types get overriden by default when undefined
+{
+	type T = Partial<{
+		timeout: number;
+	}>;
+
+	const options: T = {};
+	const defaultOptions: Required<T> = {timeout: 100};
+	const result = defaults(options, defaultOptions);
+
+	// Expect result to be Required<T>
+	type Result = typeof result;
+	type Expected = Required<T>;
+	const _result: Expected = result;
+
+	// Safe to use now
+	console.log(result.timeout > 0);
+}


### PR DESCRIPTION
When determining return type, use the default object type if it's defined and overriding an undefined type.

Fixes https://github.com/sindresorhus/node-defaults/issues/5